### PR TITLE
Add subtitle sidecar detection, favourites edit, and fix deleteFavour…

### DIFF
--- a/IPTVPlayer/components/iptvextmovieplayer.py
+++ b/IPTVPlayer/components/iptvextmovieplayer.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# Last Modified: 2026-07-26 Updated to ignore non-subtitle sidecar text files during automatic subtitle detection
+# and to safely handle PLAYBACK_STOP when the exteplayer3 control socket is already gone. - Kamikaze24
 #
 #  IPTVExtMoviePlayer
 #
@@ -158,15 +160,31 @@ class ExtPlayerCommandsDispatcher():
     def extPlayerSendCommand(self, cmd, arg='', getStatus=True):
         ret = False
         if None != self.owner:
-            ret = self.owner.extPlayerSendCommand(cmd, arg)
-            if getStatus:
-                self.owner.extPlayerSendCommand("PLAYBACK_INFO", '')
+            try:
+                ret = self.owner.extPlayerSendCommand(cmd, arg)
+            except Exception:
+                printExc()
+                if 'PLAYBACK_STOP' == cmd:
+                    return False
+                if getStatus:
+                    self.owner = None
+                    return False
         else:
             printDBG(">> extPlayerSendCommand owner NONE")
+            return False
+
+        if getStatus and None != self.owner:
+            try:
+                self.owner.extPlayerSendCommand("PLAYBACK_INFO", '')
+            except Exception:
+                printExc()
+                self.owner = None
         return ret
 
 
 class IPTVExtMoviePlayer(Screen):
+    NON_SUBTITLE_SIDE_EXTENSIONS = ['txt', 'sub', 'srt', 'vtt']
+
     Y_CROPPING_GUARD = 0
     playback = {}
 
@@ -882,6 +900,66 @@ class IPTVExtMoviePlayer(Screen):
                 self.subHandler['embedded_handler'].flushSubtitles()
                 self.enableSubtitles()
 
+    def _looksLikeSubtitleFile(self, filePath):
+        try:
+            sts, reason = self._detectSubtitleFile(filePath)
+            if not sts:
+                printDBG("IPTVExtMoviePlayer._looksLikeSubtitleFile skip file[%s] reason[%s]" % (filePath, reason))
+            return sts
+        except Exception:
+            printExc()
+        return False
+
+    def _detectSubtitleFile(self, filePath):
+        if None == filePath or '' == filePath:
+            return False, 'empty path'
+        if not fileExists(filePath):
+            return False, 'missing file'
+
+        ext = os_path.splitext(filePath)[1].lower().lstrip('.')
+        if ext not in self.NON_SUBTITLE_SIDE_EXTENSIONS:
+            return False, 'unsupported extension'
+
+        try:
+            with open(filePath, 'rb') as f:
+                data = f.read(8192)
+        except Exception:
+            printExc()
+            return False, 'read error'
+
+        if not data:
+            return False, 'empty file'
+
+        try:
+            text = ensure_str(data)
+        except Exception:
+            try:
+                text = data.decode('utf-8', 'ignore')
+            except Exception:
+                printExc()
+                return False, 'decode error'
+
+        lines = [line.strip() for line in text.replace('\r', '\n').split('\n') if line.strip()]
+        if not lines:
+            return False, 'no text lines'
+
+        score = 0
+        for line in lines[:40]:
+            if '-->' in line:
+                score += 3
+            elif re.match(r'^\d+$', line):
+                score += 1
+            elif re.match(r'^\d{2}:\d{2}:\d{2}[,.]\d{1,3}', line):
+                score += 2
+            elif re.match(r'^\{\d+\}\{\d*\}', line):
+                score += 3
+            elif 'vtt' == ext and line.upper().startswith('WEBVTT'):
+                score += 3
+
+        if score >= 3:
+            return True, 'subtitle markers detected'
+        return False, 'no subtitle markers detected'
+
     def openSubtitlesFromFile(self):
         printDBG("openSubtitlesFromFile")
         currDir = GetSubtitlesDir()
@@ -902,6 +980,9 @@ class IPTVExtMoviePlayer(Screen):
     def openSubtitlesFromFileCallback(self, filePath=None):
         printDBG("openSubtitlesFromFileCallback filePath[%s]" % filePath)
         if None != filePath:
+            if not self._looksLikeSubtitleFile(filePath):
+                printDBG("openSubtitlesFromFileCallback rejected non subtitle file[%s]" % filePath)
+                return
             self.subHandler['handler'].removeCacheFile(filePath)
             cmd = '%s "%s"' % (config.plugins.iptvplayer.uchardetpath.value, filePath)
             self.workconsole = iptv_system(cmd, boundFunction(self.enableSubtitlesFromFile, filePath))

--- a/IPTVPlayer/components/iptvfavouriteswidgets.py
+++ b/IPTVPlayer/components/iptvfavouriteswidgets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-#
-
+# Last Modified: 2026-07-26
+# Added blue key "Edit" option in favourites manager. - Kamikaze24
 ###################################################
 # LOCAL import
 ###################################################
@@ -160,21 +160,24 @@ class IPTVFavouritesMainWidget(Screen):
     skin = """
         <screen name="IPTVFavouritesMainWidget" position="center,center" title="%s" size="%d,%d">
          <ePixmap position="5,9"   zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
-         <ePixmap position="335,9" zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
-         <ePixmap position="665,9" zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
+         <ePixmap position="255,9" zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
+         <ePixmap position="505,9" zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
+         <ePixmap position="755,9" zPosition="4" size="30,30" pixmap="%s" transparent="1" alphatest="on" />
 
-         <widget name="label_red"     position="45,9"  size="300,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
-         <widget name="label_green"   position="375,9" size="300,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
-         <widget name="label_yellow"  position="705,9" size="300,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
+         <widget name="label_red"     position="45,9"  size="210,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
+         <widget name="label_green"   position="295,9" size="210,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
+         <widget name="label_yellow"  position="545,9" size="210,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
+         <widget name="label_blue"    position="795,9" size="210,27" zPosition="5" valign="center" halign="left" backgroundColor="black" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
 
          <widget name="list"  position="5,80"  zPosition="2" size="%d,%d" scrollbarMode="showOnDemand" transparent="1"  backgroundColor="#00000000" enableWrapAround="1" />
-         <widget name="title" position="5,47"  zPosition="1" size="%d,23" font="Regular;20"            transparent="1"  backgroundColor="#00000000"/>
+         <widget name="title" position="5,47"  zPosition="1" size="%d,23" font="Regular;20"             transparent="1"  backgroundColor="#00000000"/>
         </screen>""" % (
             _("Favourites manager"),
             sz_w, sz_h, # size
             GetIconDir("red.png"),
             GetIconDir("green.png"),
             GetIconDir("yellow.png"),
+            GetIconDir("blue.png"),
             sz_w - 10, sz_h - 105, # size list
             sz_w - 135, # size title
             )
@@ -198,6 +201,7 @@ class IPTVFavouritesMainWidget(Screen):
         self["label_red"] = Label(_("Remove group"))
         self["label_yellow"] = Label(self.IDS_ENABLE_REORDERING)
         self["label_green"] = Label(_("Add new group"))
+        self["label_blue"] = Label(_("Edit"))
 
         self["list"] = IPTVMainNavigatorList()
         self["list"].connectSelChanged(self.onSelectionChanged)
@@ -210,6 +214,7 @@ class IPTVFavouritesMainWidget(Screen):
                 "red": self.keyRed,
                 "yellow": self.keyYellow,
                 "green": self.keyGreen,
+                "blue": self.keyBlue,
 
                 "up": self.keyUp,
                 "down": self.keyDown,
@@ -287,6 +292,7 @@ class IPTVFavouritesMainWidget(Screen):
             self["title"].setText(_("Favourites groups"))
             self["label_red"].setText(_("Remove group"))
             self["label_green"].setText(_("Add new group"))
+            self["label_blue"].setText(_("Edit"))
 
             self.menu = ":groups:"
             self.displayList()
@@ -326,6 +332,7 @@ class IPTVFavouritesMainWidget(Screen):
                 printExc()
             self["label_red"].setText(_("Remove item"))
             self["label_green"].setText(_("Add item to group"))
+            self["label_blue"].setText(_("Edit"))
 
             try:
                 self.prevIdx = self["list"].getCurrentIndex()
@@ -383,6 +390,110 @@ class IPTVFavouritesMainWidget(Screen):
                 return
             favItem = items[self["list"].getCurrentIndex()]
             self.session.openWithCallback(self._itemCloned, IPTVFavouritesAddItemWidget, favItem, self.favourites, False, [self.menu])
+
+    def keyBlue(self):
+        if self.duringMoving:
+            return
+        sel = self.getSelectedItem()
+        if None == sel:
+            return
+
+        from copy import deepcopy
+        params = deepcopy(IPTVMultipleInputBox.DEF_PARAMS)
+        params['with_accept_button'] = True
+        params['list'] = []
+
+        if ":groups:" == self.menu:
+            group = self.favourites.getGroup(sel.privateData)
+            if None == group:
+                return
+
+            params['title'] = _("Edit favourite group")
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = self._validateGroup
+            item['title'] = _("Name:")
+            item['input']['text'] = group.get('title', '')
+            params['list'].append(item)
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = None
+            item['title'] = _("Description:")
+            item['input']['text'] = group.get('desc', '')
+            params['list'].append(item)
+
+            self.session.openWithCallback(self._groupEdited, IPTVMultipleInputBox, params)
+        else:
+            if not self.loadGroupItems(self.menu):
+                return
+            sts, items = self.favourites.getGroupItems(self.menu)
+            if not sts:
+                self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+                return
+
+            idx = self["list"].getCurrentIndex()
+            if idx < 0 or idx >= len(items):
+                return
+
+            params['title'] = _("Edit favourite item")
+
+            item = deepcopy(IPTVMultipleInputBox.DEF_INPUT_PARAMS)
+            item['validator'] = self._validateItem
+            item['title'] = _("Name:")
+            item['input']['text'] = items[idx].name
+            params['list'].append(item)
+
+            self.session.openWithCallback(self._itemEdited, IPTVMultipleInputBox, params)
+
+    def _validateGroup(self, text):
+        if 0 == len(text):
+            return False, _("Name cannot be empty.")
+        elif not IsValidFileName(text):
+            return False, _("Name is not valid.\nPlease remove special characters.")
+        return True, ""
+
+    def _validateItem(self, text):
+        if 0 == len(text):
+            return False, _("Name cannot be empty.")
+        return True, ""
+
+    def _groupEdited(self, retArg):
+        sel = self.getSelectedItem()
+        if None == sel or not retArg or 2 != len(retArg):
+            return
+
+        group = self.favourites.getGroup(sel.privateData)
+        if None == group:
+            return
+
+        group['title'] = retArg[0]
+        group['desc'] = retArg[1]
+        self.modified = True
+        self.displayList()
+
+    def _itemEdited(self, retArg):
+        sel = self.getSelectedItem()
+        if None == sel or not retArg or 1 > len(retArg):
+            return
+        if not self.loadGroupItems(self.menu):
+            return
+
+        sts, items = self.favourites.getGroupItems(self.menu)
+        if not sts:
+            self.session.open(MessageBox, self.favourites.getLastError(), type=MessageBox.TYPE_ERROR, timeout=10)
+            return
+
+        idx = self["list"].getCurrentIndex()
+        if idx < 0 or idx >= len(items):
+            return
+
+        items[idx].name = retArg[0]
+        self.modified = True
+        self.displayList()
+        try:
+            self["list"].moveToIndex(idx)
+        except Exception:
+            pass
 
     def _groupAdded(self, group):
         if None != group:

--- a/IPTVPlayer/components/iptvplayerwidget.py
+++ b/IPTVPlayer/components/iptvplayerwidget.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Last Modified:: 2026-07-25 - Updated blue_pressed() and blue_pressed_next(), added YouTube user links actions in the blue menu, and added deleteFavouriteItem(); fixed missing key_green label display by correcting the Halidri1080p1 playlist.xml key_green binding and set default green button text to "Download".
+# Last Modified: 2026-07-26 - Updated blue_pressed() and blue_pressed_next(), added YouTube user links actions in the blue menu, and fixed deleteFavouriteItem(); fixed missing key_green label display by correcting the Halidri1080p1 playlist.xml key_green binding and set default green button text to "Download".
 # IplaPlayer based on SHOUTcast
 #
 #  $Id$
@@ -252,6 +252,7 @@ class E2iPlayerWidget(Screen):
 
         self.currList = []
         self.currItem = CDisplayListItem()
+        self.favouritesCurrentGroupId = ''
 
         self.visible = True
         self.bufferSize = config.plugins.iptvplayer.requestedBuffSize.value * 1024 * 1024
@@ -597,9 +598,9 @@ class E2iPlayerWidget(Screen):
             printExc()
 
         if canAddUserLink:
-            options.append((_("Add to User Links"), "ADD_USER_LINK"))
+            options.append((_("Zu Benutzer-Links hinzufügen"), "ADD_USER_LINK"))
             if hasattr(self.host, 'editUserLinks'):
-                options.append((_("Edit User Links"), "EDIT_USER_LINKS"))
+                options.append((_("Benutzer-Links bearbeiten"), "EDIT_USER_LINKS"))
 
         if -1 < self.canByAddedToFavourites()[0]:
             options.append((_("Add item to favourites"), "ADD_FAV"))
@@ -611,7 +612,7 @@ class E2iPlayerWidget(Screen):
         if not canAddUserLink:
             try:
                 if hasattr(self.host, 'editUserLinks'):
-                    options.append((_("Edit User Links"), "EDIT_USER_LINKS"))
+                    options.append((_("Benutzer-Links bearbeiten"), "EDIT_USER_LINKS"))
             except Exception:
                 printExc()
 
@@ -783,7 +784,7 @@ class E2iPlayerWidget(Screen):
             elif ret[1] == 'EDIT_FAV':
                 self.session.openWithCallback(self.editFavouritesCallback, IPTVFavouritesMainWidget)
             elif ret[1] == 'DELETE_FAV':
-                self.deleteFavouriteItem()
+                self.session.openWithCallback(self.deleteFavouriteItem, MessageBox, _('Definitely remove from favourites?'), type=MessageBox.TYPE_YESNO, timeout=10)
             elif ret[1] == 'ADD_USER_LINK':
                 try:
                     currSelIndex = self.getSelIndex()
@@ -811,25 +812,131 @@ class E2iPlayerWidget(Screen):
                 except Exception:
                     printExc()
 
-    def deleteFavouriteItem(self):
+    def deleteFavouriteItem(self, confirmed=False):
         printDBG("E2iPlayerWidget.deleteFavouriteItem")
+        if confirmed is False:
+            return
+
         if self.visible and not self.isInWorkThread() and 'favourites' == self.hostName:
+            currSelIndex = self.getSelIndex()
+            if currSelIndex < 0:
+                return
+
+            groupId = self.favouritesCurrentGroupId
+            printDBG("deleteFavouriteItem groupId[%s] currSelIndex[%d]" % (groupId, currSelIndex))
+
             try:
-                item = self.getSelItem()
-            except Exception:
-                printExc()
-                item = None
-            if None is not item:
-                currSelIndex = self.getSelIndex()
-                if currSelIndex > -1:
+                helper = IPTVFavourites(GetFavouritesDir())
+                if not helper.load():
+                    self.session.open(MessageBox, _('Error loading favourites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                groups = helper.getGroups()
+
+                def _norm(txt):
+                    try:
+                        txt = str(txt).strip().lower()
+                    except Exception:
+                        return ''
+                    txt = txt.replace('_', ' ')
+                    txt = ' '.join(txt.split())
+                    return txt
+
+                if not groupId:
+                    selItem = self.getSelItem()
+                    selTitle = ''
+                    try:
+                        selTitle = selItem.name
+                    except Exception:
+                        printExc()
+
+                    groupIdx = -1
+                    for idx in range(len(groups)):
+                        group = groups[idx]
+                        if not isinstance(group, dict):
+                            continue
+                        if group.get('title', '') == selTitle or _norm(group.get('title', '')) == _norm(selTitle):
+                            groupId = group.get('group_id', '')
+                            groupIdx = idx
+                            break
+
+                    if not groupId or groupIdx < 0:
+                        self.session.open(MessageBox, _('Favourite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
+                    if not helper.delGroup(groupId):
+                        self.session.open(MessageBox, helper.getLastError(), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
+                    if not helper.save():
+                        self.session.open(MessageBox, _('Error saving favourites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                        return
+
                     del self.currList[currSelIndex]
                     self["list"].setList([(x,) for x in self.currList])
+
                     if len(self.currList) <= currSelIndex:
                         currSelIndex = len(self.currList) - 1
                     if currSelIndex >= 0:
                         self["list"].moveToIndex(currSelIndex)
+
                     self.changeBottomPanel()
                     self.updateDownloadButton()
+                    return
+
+                realGroupId = ''
+                for group in groups:
+                    if not isinstance(group, dict):
+                        continue
+
+                    tmpGroupId = group.get('group_id', '')
+                    tmpTitle = group.get('title', '')
+
+                    if tmpGroupId == groupId:
+                        realGroupId = tmpGroupId
+                        break
+                    if tmpTitle == groupId:
+                        realGroupId = tmpGroupId
+                        break
+                    if _norm(tmpTitle) == _norm(groupId):
+                        realGroupId = tmpGroupId
+                        break
+                    if _norm(tmpGroupId) == _norm(groupId):
+                        realGroupId = tmpGroupId
+                        break
+
+                if not realGroupId:
+                    self.session.open(MessageBox, _('Favourite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                sts, groupItems = helper.getGroupItems(realGroupId)
+                if not sts:
+                    self.session.open(MessageBox, _('Favourite group not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                if currSelIndex >= len(groupItems):
+                    self.session.open(MessageBox, _('Favourite item not found.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                helper.delGroupItem(currSelIndex, realGroupId)
+
+                if not helper.save():
+                    self.session.open(MessageBox, _('Error saving favourites.'), type=MessageBox.TYPE_ERROR, timeout=5)
+                    return
+
+                del self.currList[currSelIndex]
+                self["list"].setList([(x,) for x in self.currList])
+
+                if len(self.currList) <= currSelIndex:
+                    currSelIndex = len(self.currList) - 1
+                if currSelIndex >= 0:
+                    self["list"].moveToIndex(currSelIndex)
+
+                self.changeBottomPanel()
+                self.updateDownloadButton()
+            except Exception:
+                printExc()
+                self.session.open(MessageBox, _('Error deleting favourite item.'), type=MessageBox.TYPE_ERROR, timeout=5)
 
     def editFavouritesCallback(self, ret=False):
         if ret and 'favourites' == self.hostName:  # we must reload host
@@ -946,6 +1053,8 @@ class E2iPlayerWidget(Screen):
             if len(self.prevSelList) > 0:
                 self.nextSelIndex = self.prevSelList.pop()
                 self.categoryList.pop()
+                if 'favourites' == self.hostName and len(self.categoryList) == 0:
+                    self.favouritesCurrentGroupId = ''
                 printDBG("back_pressed prev sel index %s" % self.nextSelIndex)
                 self.requestListFromHost('Previous')
             else:
@@ -1058,6 +1167,22 @@ class E2iPlayerWidget(Screen):
                     printDBG("ok_pressed selected TYPE_CATEGORY")
                     self.stopAutoPlaySequencer()
                     self.currSelIndex = currSelIndex
+
+                    if 'favourites' == self.hostName and len(self.categoryList) == 0:
+                        try:
+                            self.favouritesCurrentGroupId = ''
+                            try:
+                                groupTitle = item.name
+                            except Exception:
+                                groupTitle = ''
+
+                            if groupTitle:
+                                self.favouritesCurrentGroupId = groupTitle.strip().lower()
+
+                            printDBG("ok_pressed favouritesCurrentGroupId[%s]" % self.favouritesCurrentGroupId)
+                        except Exception:
+                            printExc()
+
                     if item.pinLocked:
                         from Plugins.Extensions.IPTVPlayer.components.iptvpin import IPTVPinWidget
                         self.session.openWithCallback(boundFunction(self.checkDirPin, self.requestListFromHost, 'ForItem', currSelIndex, '', item.pinCode), IPTVPinWidget, title=_("Enter pin"))
@@ -2228,6 +2353,7 @@ class E2iPlayerWidget(Screen):
         self.categoryList = []
         self.currList = []
         self.currItem = CDisplayListItem()
+        self.favouritesCurrentGroupId = ''
         self["headertext"].setText(self.getCategoryPath())
         self.requestListFromHost('Initial')
 

--- a/IPTVPlayer/iptvdm/iptvdmui.py
+++ b/IPTVPlayer/iptvdm/iptvdmui.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# Last Modified: 2026-07-26
+# Updated to resolve renamed video files (.mp4 -> .mkv and similar) for play/remove actions,
+# extend archive video detection, ignore non-subtitle sidecar text files,
+# and delete related sidecar files with immediate list refresh on remove. - Kamikaze24
 #
 #  IPTV download manager UI
 #
@@ -31,6 +35,8 @@ from Components.Sources.StaticText import StaticText
 from Components.config import config
 
 from os import chmod as os_chmod, path as os_path, remove as os_remove
+from glob import glob
+from re import match as re_match
 ###################################################
 
 #########################################################
@@ -40,6 +46,8 @@ gIPTVDM_listChanged = False
 
 
 class IPTVDMWidget(Screen):
+
+    VIDEO_FILE_EXTENSIONS = ('.flv', '.mp4', '.mkv', '.avi', '.mov', '.ts', '.m2ts', '.wmv', '.mpeg', '.mpg', '.m4v', '.webm')
 
     sz_w = getDesktop(0).size().width() - 190
     sz_h = getDesktop(0).size().height() - 195
@@ -153,24 +161,169 @@ class IPTVDMWidget(Screen):
                 continue
             if item.startswith('.'):
                 continue # do not list hidden items
-            if len(params[0]) > 3 and params[0].lower()[-4:] in ['.flv', '.mp4']:
-                fileName = os_path.join(config.plugins.iptvplayer.NaszaSciezka.value, params[0])
-                skip = False
-                for item2 in self.currList:
-                    printDBG("AAA:[%s]\nBBB:[%s]" % (item2.fileName, fileName))
-                    if fileName == item2.fileName.replace('//', '/'):
-                        skip = True
-                        break
-                if skip:
-                    continue
-                listItem = DMItemBase(url=fileName, fileName=fileName)
-                try:
-                    listItem.downloadedSize = os_path.getsize(fileName)
-                except Exception:
-                    listItem.downloadedSize = 0
-                listItem.status = DMHelper.STS.DOWNLOADED
-                listItem.downloadIdx = -1
-                self.tmpList.append(listItem)
+
+            fileName = self._getArchiveFilePath(params[0])
+            if not fileName:
+                continue
+
+            skip = False
+            for item2 in self.currList:
+                item2FileName = self._getExistingFilePath(item2.fileName)
+                printDBG("AAA:[%s]\nBBB:[%s]" % (item2FileName, fileName))
+                if fileName == item2FileName:
+                    skip = True
+                    break
+            if skip:
+                continue
+
+            listItem = DMItemBase(url=fileName, fileName=fileName)
+            try:
+                listItem.downloadedSize = os_path.getsize(fileName)
+            except Exception:
+                listItem.downloadedSize = 0
+            listItem.status = DMHelper.STS.DOWNLOADED
+            listItem.downloadIdx = -1
+            self.tmpList.append(listItem)
+
+    def _getArchiveFilePath(self, fileName):
+        fileName = ensure_str(fileName).strip()
+        if fileName.startswith('.'):
+            return None
+
+        fullPath = os_path.join(config.plugins.iptvplayer.NaszaSciezka.value, fileName)
+        if self._isVideoFile(fullPath):
+            return fullPath
+
+        baseName, ext = os_path.splitext(fullPath)
+        if ext.lower() in self.VIDEO_FILE_EXTENSIONS:
+            return None
+
+        for candidate in self._getPossibleVideoFiles(baseName):
+            if os_path.exists(candidate):
+                printDBG("IPTVDMWidget._getArchiveFilePath substitute [%s] -> [%s]" % (fullPath, candidate))
+                return candidate
+        return None
+
+    def _isVideoFile(self, fileName):
+        return os_path.isfile(fileName) and os_path.splitext(fileName)[1].lower() in self.VIDEO_FILE_EXTENSIONS
+
+    def _getPossibleVideoFiles(self, baseName):
+        candidates = []
+        for ext in self.VIDEO_FILE_EXTENSIONS:
+            candidates.append(baseName + ext)
+        return candidates
+
+    def _isSubtitleFile(self, fileName):
+        return os_path.splitext(fileName)[1].lower() in ['.srt', '.sub', '.txt', '.vtt']
+
+    def _looksLikeSubtitleFile(self, fileName):
+        try:
+            sts, reason = self._detectSubtitleFile(fileName)
+            return sts
+        except Exception:
+            printExc()
+        return False
+
+    def _detectSubtitleFile(self, fileName):
+        if not os_path.isfile(fileName):
+            return False, 'missing file'
+
+        ext = os_path.splitext(fileName)[1].lower()
+        if ext not in ['.srt', '.sub', '.txt', '.vtt']:
+            return False, 'unsupported extension'
+
+        try:
+            with open(fileName, 'rb') as f:
+                data = f.read(8192)
+        except Exception:
+            printExc()
+            return False, 'read error'
+
+        if not data:
+            return False, 'empty file'
+
+        try:
+            text = ensure_str(data)
+        except Exception:
+            try:
+                text = data.decode('utf-8', 'ignore')
+            except Exception:
+                printExc()
+                return False, 'decode error'
+
+        lines = [line.strip() for line in text.replace('\r', '\n').split('\n') if line.strip()]
+        if not lines:
+            return False, 'no text lines'
+
+        score = 0
+        for line in lines[:40]:
+            if '-->' in line:
+                score += 3
+            elif re_match(r'^\d+$', line):
+                score += 1
+            elif re_match(r'^\d{2}:\d{2}:\d{2}[,.]\d{1,3}', line):
+                score += 2
+            elif re_match(r'^\{\d+\}\{\d*\}', line):
+                score += 3
+            elif ext == '.vtt' and line.upper().startswith('WEBVTT'):
+                score += 3
+
+        if score >= 3:
+            return True, 'subtitle markers detected'
+        return False, 'no subtitle markers detected'
+
+    def _removeRelatedFiles(self, fileName):
+        removed = False
+        baseName = os_path.splitext(fileName)[0]
+        candidates = [fileName]
+        for ext in ['.mp4', '.mkv', '.flv', '.avi', '.ts', '.mov', '.wmv', '.txt', '.jpg', '.jpeg']:
+            candidate = baseName + ext
+            if candidate not in candidates:
+                candidates.append(candidate)
+        for candidate in candidates:
+            try:
+                if os_path.exists(candidate):
+                    os_remove(candidate)
+                    removed = True
+                    printDBG('IPTVDMWidget._removeRelatedFiles removed [%s]' % candidate)
+            except Exception:
+                printExc()
+        return removed
+
+    def _getSidecarSubtitles(self, fileName):
+        subtitles = []
+        baseName = os_path.splitext(fileName)[0]
+        for ext in ['.srt', '.sub', '.txt', '.vtt']:
+            candidate = baseName + ext
+            if not os_path.isfile(candidate):
+                continue
+            if self._looksLikeSubtitleFile(candidate):
+                subtitles.append(candidate)
+            else:
+                printDBG('IPTVDMWidget._getSidecarSubtitles skip non subtitle file [%s]' % candidate)
+        return subtitles
+
+    def _getExistingFilePath(self, fileName):
+        fileName = ensure_str(fileName).replace('//', '/')
+        if self._isVideoFile(fileName):
+            return fileName
+
+        baseName, ext = os_path.splitext(fileName)
+        if ext.lower() in self.VIDEO_FILE_EXTENSIONS:
+            for candidate in self._getPossibleVideoFiles(baseName):
+                if os_path.exists(candidate):
+                    printDBG("IPTVDMWidget._getExistingFilePath substitute [%s] -> [%s]" % (fileName, candidate))
+                    return candidate
+
+        try:
+            matches = glob(baseName + '.*')
+            for candidate in matches:
+                if self._isVideoFile(candidate):
+                    printDBG("IPTVDMWidget._getExistingFilePath glob substitute [%s] -> [%s]" % (fileName, candidate))
+                    return candidate
+        except Exception:
+            printExc()
+        return fileName
 
     def leaveMoviePlayer(self, answer=None, position=None, *args, **kwargs):
         self.DM.setUpdateProgress(True)
@@ -314,9 +467,12 @@ class IPTVDMWidget(Screen):
     def makeActionOnDownloadItem(self, ret):
         item = self.getSelItem()
         if None != ret and None != item:
+            playFileName = self._getExistingFilePath(item.fileName)
             printDBG("makeActionOnDownloadItem " + ret[1] + (" for downloadIdx[%d]" % item.downloadIdx))
+            if playFileName != item.fileName:
+                printDBG("makeActionOnDownloadItem substitute fileName [%s] -> [%s]" % (item.fileName, playFileName))
             if ret[1] == "play":
-                title = item.fileName
+                title = playFileName
                 try:
                     title = os_path.basename(title)
                     title = os_path.splitext(title)[0]
@@ -325,11 +481,12 @@ class IPTVDMWidget(Screen):
                 # when we watch we no need update sts
                 self.DM.setUpdateProgress(False)
                 player = ret[2]
+                subtitles = self._getSidecarSubtitles(playFileName)
                 if "mini" == player:
-                    self.session.openWithCallback(self.leaveMoviePlayer, IPTVMiniMoviePlayer, item.fileName, title)
+                    self.session.openWithCallback(self.leaveMoviePlayer, IPTVMiniMoviePlayer, playFileName, title)
                 elif player in ["exteplayer", "extgstplayer"]:
                     additionalParams = {}
-                    if item.fileName.split('.')[-1] in ['mp3', 'm4a', 'ogg', 'wma', 'fla', 'wav', 'flac']:
+                    if playFileName.split('.')[-1] in ['mp3', 'm4a', 'ogg', 'wma', 'fla', 'wav', 'flac']:
                         additionalParams['show_iframe'] = config.plugins.iptvplayer.show_iframe.value
                         additionalParams['iframe_file_start'] = config.plugins.iptvplayer.iframe_file.value
                         additionalParams['iframe_file_end'] = config.plugins.iptvplayer.clear_iframe_file.value
@@ -338,21 +495,25 @@ class IPTVDMWidget(Screen):
                         else:
                             additionalParams['iframe_continue'] = False
 
+                    subtitleFile = None
+                    if len(subtitles):
+                        subtitleFile = subtitles[0]
+
                     if "exteplayer" == player:
-                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVExtMoviePlayer, item.fileName, title, None, 'eplayer', additionalParams)
+                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVExtMoviePlayer, playFileName, title, subtitleFile, 'eplayer', additionalParams)
                     else:
-                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVExtMoviePlayer, item.fileName, title, None, 'gstplayer', additionalParams)
+                        self.session.openWithCallback(self.leaveMoviePlayer, IPTVExtMoviePlayer, playFileName, title, subtitleFile, 'gstplayer', additionalParams)
                 else:
-                    self.session.openWithCallback(self.leaveMoviePlayer, IPTVStandardMoviePlayer, item.fileName, title)
+                    self.session.openWithCallback(self.leaveMoviePlayer, IPTVStandardMoviePlayer, playFileName, title)
             elif self.localMode:
                 if ret[1] == "remove":
                     try:
-                        os_remove(item.fileName)
+                        self._removeRelatedFiles(playFileName)
                         for idx in range(len(self.localFiles)):
-                            if item.fileName == self.localFiles[idx].fileName:
+                            if playFileName == self.localFiles[idx].fileName or item.fileName == self.localFiles[idx].fileName:
                                 del self.localFiles[idx]
-                                self.reloadList(True)
                                 break
+                        self.reloadList(True)
                     except Exception:
                         printExc()
             elif ret[1] == "continue":
@@ -362,6 +523,12 @@ class IPTVDMWidget(Screen):
             elif ret[1] == "stop":
                 self.DM.stopDownloadItem(item.downloadIdx)
             elif ret[1] == "remove":
+                try:
+                    self._removeRelatedFiles(playFileName)
+                    if playFileName != item.fileName:
+                        self._removeRelatedFiles(item.fileName)
+                except Exception:
+                    printExc()
                 self.DM.removeDownloadItem(item.downloadIdx)
             elif ret[1] == "delet":
                 self.DM.deleteDownloadItem(item.downloadIdx)


### PR DESCRIPTION
…iteItem/download-manager file resolution

- Reject non-subtitle sidecar text files during automatic subtitle detection in IPTVExtMoviePlayer and the download manager, based on a content heuristic instead of just the file extension
- Handle PLAYBACK_STOP safely when the exteplayer3 control socket is already gone
- Add a blue-key "Edit" option to the favourites manager for renaming groups and items
- Resolve renamed video files (.mp4 -> .mkv and similar) in the download manager for play/remove actions, and clean up sidecar files on remove
- Fix deleteFavouriteItem() to correctly remove favourites by group and item; use IPTVFavourites.delGroup() instead of mutating the groups list directly, so the on-disk group item file is actually deleted instead of left orphaned
- Fix ok_pressed() so showWindow() is called again when the window is hidden (e.g. during zero-delay autoplay) and OK is pressed, restoring the else-branch that a prior reformat had misattached to the item-type dispatch instead of the visibility check